### PR TITLE
fixed cursed duck typing in legacy octoprint events

### DIFF
--- a/print_nanny_webapp/telemetry/models.py
+++ b/print_nanny_webapp/telemetry/models.py
@@ -69,7 +69,7 @@ class TelemetryEvent(PolymorphicModel):
     user = models.ForeignKey(User, on_delete=models.CASCADE, db_index=True)
     print_nanny_plugin_version = models.CharField(max_length=60)
     print_nanny_client_version = models.CharField(max_length=60)
-    print_nanny_beta_client_version = models.CharField(max_length=60, null=True)
+    print_nanny_beta_client_version = models.CharField(max_length=60)
     octoprint_version = models.CharField(max_length=36)
     print_session = models.ForeignKey(
         "remote_control.PrintSession",
@@ -86,9 +86,8 @@ class RemoteCommandEvent(TelemetryEvent):
 
     def __init__(self, *args, **kwargs):
         if "event_source" in kwargs.keys():
-            event_source = kwargs.pop("event_source")
-        else:
-            event_source = EventSource.REMOTE_COMMAND
+            kwargs.pop("event_source")
+        event_source = EventSource.REMOTE_COMMAND
         return super().__init__(*args, event_source=event_source, **kwargs)
 
     event_codes = [x.value for x in RemoteCommandEventType.__members__.values()]
@@ -105,9 +104,8 @@ class PrintNannyPluginEvent(TelemetryEvent):
 
     def __init__(self, *args, **kwargs):
         if "event_source" in kwargs.keys():
-            event_source = kwargs.pop("event_source")
-        else:
-            event_source = event_source = EventSource.PRINT_NANNY_PLUGIN
+            kwargs.pop("event_source")
+        event_source = event_source = EventSource.PRINT_NANNY_PLUGIN
         return super().__init__(*args, event_source=event_source, **kwargs)
 
     plugin_identifier = "octoprint_nanny"
@@ -129,9 +127,8 @@ class OctoPrintEvent(TelemetryEvent):
 
     def __init__(self, *args, **kwargs):
         if "event_source" in kwargs.keys():
-            event_source = kwargs.pop("event_source")
-        else:
-            event_source = EventSource.OCTOPRINT
+            kwargs.pop("event_source")
+        event_source = EventSource.OCTOPRINT
         return super().__init__(*args, event_source=event_source, **kwargs)
 
     event_codes = [x.value for x in OctoprintEventType.__members__.values()]
@@ -140,9 +137,8 @@ class OctoPrintEvent(TelemetryEvent):
 class PrinterEvent(TelemetryEvent):
     def __init__(self, *args, **kwargs):
         if "event_source" in kwargs.keys():
-            event_source = kwargs.pop("event_source")
-        else:
-            event_source = EventSource.OCTOPRINT
+            kwargs.pop("event_source")
+        event_source = EventSource.OCTOPRINT
         return super().__init__(*args, event_source=event_source, **kwargs)
 
     CSS_CLASS_MAP = {
@@ -177,9 +173,8 @@ class PrinterEvent(TelemetryEvent):
 class PrintJobEvent(TelemetryEvent):
     def __init__(self, *args, **kwargs):
         if "event_source" in kwargs.keys():
-            event_source = kwargs.pop("event_source")
-        else:
-            event_source = EventSource.OCTOPRINT
+            kwargs.pop("event_source")
+        event_source = EventSource.OCTOPRINT
         return super().__init__(*args, event_source=event_source, **kwargs)
 
     event_codes = [x.value for x in PrintJobEventType.__members__.values()]

--- a/print_nanny_webapp/telemetry/models.py
+++ b/print_nanny_webapp/telemetry/models.py
@@ -69,7 +69,7 @@ class TelemetryEvent(PolymorphicModel):
     user = models.ForeignKey(User, on_delete=models.CASCADE, db_index=True)
     print_nanny_plugin_version = models.CharField(max_length=60)
     print_nanny_client_version = models.CharField(max_length=60)
-    print_nanny_beta_client_version = models.CharField(max_length=60)
+    print_nanny_beta_client_version = models.CharField(max_length=60, null=True)
     octoprint_version = models.CharField(max_length=36)
     print_session = models.ForeignKey(
         "remote_control.PrintSession",


### PR DESCRIPTION
Fixes deserialization issues where provided `event_source=` is None

```
Error
2022-01-02 12:29:10.416 PSTERROR 2022-01-02 20:29:10,415 octoprint_events 1 140208737613568 Meta deserialization failed with errors {'event_source': [ErrorDetail(string='This field may not be null.', code='null')]} and data {'ts': 1641155349.351981, 'event_source': None, 'event_type': 'plugin_octoprint_nanny_connect_test_mqtt_ping_success', 'octoprint_environment': {'os': {'id': 'linux', 'platform': 'linux', 'bits': 32}, 'python': {'version': '3.7.3', 'pip': '20.3.3', 'virtualenv': '/home/pi/oprint'}, 'hardware': {'cores': 4, 'freq': 1500.0, 'ram': 3959304192}, 'pi_support': {'model': 'Raspberry Pi 4 Model B Rev 1.1', 'throttle_state': '0x0', 'octopi_version': '0.18.0'}}, 'octoprint_printer_data': {'job': {'file': {'name': None, 'path': None, 'size': None, 'origin': None, 'date': None}, 'estimatedPrintTime': None, 'lastPrintTime': None, 'filament': {'length': None, 'volume': None}, 'user': None}, 'state': {'text': 'Offline', 'flags': {'operational': False, 'printing': False, 'cancelling': False, 'pausing': False, 'resuming': False, 'finishing': False, 'closedOrError': True, 'error': False, 'paused': False, 'ready': False, 'sdReady': False}, 'error': ''}, 'user': None, 'current_z': None, 'progress': {'completion': None, 'filepos': None, 'printTime': None, 'printTimeLeft': None, 'printTimeOrigin': None}, 'resends': {'count': 0, 'ratio': 0}, 'offsets': {}}, 'event_data': {'ts': 1641155349.319401, 'event_source': None, 'event_type': 'plugin_octoprint_nanny_connect_test_mqtt_ping', 'octoprint_environment': {'os': {'id': 'linux', 'platform': 'linux', 'bits': 32}, 'python': {'version': '3.7.3', 'pip': '20.3.3', 'virtualenv': '/home/pi/oprint'}, 'hardware': {'cores': 4, 'freq': 1500.0, 'ram': 3959304192}, 'pi_support': {'model': 'Raspberry Pi 4 Model B Rev 1.1', 'throttle_state': '0x0', 'octopi_version': '0.18.0'}}, 'octoprint_printer_data': {'job': {'file': {'name': None, 'path': None, 'size': None, 'origin': None, 'date': None}, 'estimatedPrintTime': None, 'lastPrintTime': None, 'filament': {'length': None, 'volume': None}, 'user': None}, 'state': {'text': 'Offline', 'flags': {'operational': False, 'printing': False, 'cancelling': False, 'pausing': False, 'resuming': False, 'finishing': False, 'closedOrError': True, 'error': False, 'paused': False, 'ready': False, 'sdReady': False}, 'error': ''}, 'user': None, 'current_z': None, 'progress': {'completion': None, 'filepos': None, 'printTime': None, 'printTimeLeft': None, 'printTimeOrigin': None}, 'resends': {'count': 0, 'ratio': 0}, 'offsets': {}}, 'event_data': None, 'temperature': {}, 'print_nanny_plugin_version': '0.8.0', 'print_nanny_client_version': '0.8.18', 'print_nanny_beta_client_version': '0.34.1', 'octoprint_version': '1.7.2', 'octoprint_device': 54, 'print_session': None, 'printer_state': 'Offline'}, 'temperature': {}, 'print_nanny_plugin_version': '0.8.0', 'print_nanny_client_version': '0.8.18', 'print_nanny_beta_client_version': '0.34.1', 'octoprint_version': '1.7.2', 'octoprint_device': 54, 'print_session': None, 'printer_state': 'Offline'}
```