### PR TITLE
Update ingress, prepping for upgrade to 1.22

### DIFF
--- a/k8s/prod/ara.yml
+++ b/k8s/prod/ara.yml
@@ -74,7 +74,7 @@ spec:
   domains:
     - "ara.print-nanny.com"
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ara

--- a/k8s/prod/django.yml
+++ b/k8s/prod/django.yml
@@ -122,7 +122,7 @@ spec:
     enabled: true
     responseCodeName: MOVED_PERMANENTLY_DEFAULT
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: django

--- a/k8s/sandbox/ara.yml
+++ b/k8s/sandbox/ara.yml
@@ -61,7 +61,7 @@ spec:
   domains:
     - "ara.sandbox.print-nanny.com"
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ara

--- a/k8s/sandbox/services.yml
+++ b/k8s/sandbox/services.yml
@@ -8,7 +8,7 @@ spec:
     enabled: true
     responseCodeName: MOVED_PERMANENTLY_DEFAULT
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: webapp


### PR DESCRIPTION
Warning: networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress