### PR TITLE
Fix 500 errors on printer profile upsert

### DIFF
--- a/print_nanny_webapp/devices/api/views.py
+++ b/print_nanny_webapp/devices/api/views.py
@@ -1,15 +1,13 @@
 import logging
 
 from typing import Any
-from drf_spectacular.types import OpenApiTypes
 
 from drf_spectacular.utils import (
     extend_schema,
     extend_schema_view,
     OpenApiParameter,
-    OpenApiResponse,
 )
-from django.db.utils import Error, IntegrityError
+from django.db.utils import IntegrityError
 from django.http import Http404
 
 from rest_framework import status
@@ -27,7 +25,6 @@ from rest_framework.viewsets import GenericViewSet
 from .serializers import (
     CameraSerializer,
     CloudiotDeviceSerializer,
-    DeviceConfigSerializer,
     SystemInfoSerializer,
     DeviceSerializer,
     LicenseSerializer,
@@ -39,7 +36,6 @@ from ..models import (
     Camera,
     CloudiotDevice,
     Device,
-    DeviceConfig,
     SystemInfo,
     License,
     PrinterController,

--- a/print_nanny_webapp/remote_control/api/serializers.py
+++ b/print_nanny_webapp/remote_control/api/serializers.py
@@ -237,7 +237,7 @@ class PrinterProfileSerializer(serializers.ModelSerializer):
     def update_or_create(self, validated_data, user):
         unique_together = (
             "user",
-            "name",
+            "octoprint_key",
         )
         defaults = {k: v for k, v in validated_data.items() if k not in unique_together}
         unique_together_fields = {


### PR DESCRIPTION
Requests to `/api/printer-profiles/update-or-create/` are currently failing with error:
```
duplicate key value violates unique constraint "remote_control_printerpr_user_id_octoprint_key_xxx"
DETAIL:  Key (user_id, octoprint_key)=(116, xxx) already exists.
```

This is caused by the serializer treating `name` as a member of unique index, when the schema is unique on user+octoprint_key 