### PR TITLE
Resolves error in octoprint_events worker:

### DIFF
--- a/print_nanny_webapp/telemetry/models.py
+++ b/print_nanny_webapp/telemetry/models.py
@@ -56,6 +56,7 @@ class TelemetryEvent(PolymorphicModel):
         max_length=36,
         choices=EventSource.choices,
         default=EventSource.PRINT_NANNY_PLUGIN,
+        allow_null=True,
     )
     event_data = models.JSONField(default=dict, null=True)
     octoprint_environment = models.JSONField(default=dict)


### PR DESCRIPTION
2022-01-12 17:58:52.713 PSTERROR 2022-01-13 01:58:52,713 octoprint_events 1 140316816422656 Meta deserialization failed with errors {'event_source': [ErrorDetail(string='This field may not be null.', code='null')]}