### PR TITLE
fix AppRegistryNotReady

### DIFF
--- a/print_nanny_webapp/remote_control/models.py
+++ b/print_nanny_webapp/remote_control/models.py
@@ -1,10 +1,9 @@
+import json
 import logging
 from typing import Callable
 
-from print_nanny_webapp.telemetry.models import PrinterEvent, PrintJobEvent
 from typing import Dict, Any, Optional
 from django.contrib.auth import get_user_model
-import json
 from django.utils import dateformat
 from django.urls import reverse
 from django.apps import apps
@@ -27,6 +26,8 @@ from print_nanny_webapp.remote_control.services import (
     generate_keypair,
 )
 
+PrinterEvent = apps.get_model("telemetry", "PrinterEvent")
+PrintJobEvent = apps.get_model("telemetry", "PrintJobEvent")
 User = get_user_model()
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Fixes stacktrace in octoprint_events pod:
```
Error
2022-02-10 23:26:11.878 PSTTraceback (most recent call last): File "/app/print_nanny_webapp/telemetry/subscribers/octoprint_events.py", line 8, in <module> from print_nanny_webapp.remote_control.models import OctoPrintDevice File "/app/print_nanny_webapp/remote_control/models.py", line 4, in <module> from print_nanny_webapp.telemetry.models import PrinterEvent, PrintJobEvent File "/app/print_nanny_webapp/telemetry/models.py", line 7, in <module> from polymorphic.models import PolymorphicModel File "/usr/local/lib/python3.9/site-packages/polymorphic/models.py", line 4, in <module> from django.contrib.contenttypes.models import ContentType File "/usr/local/lib/python3.9/site-packages/django/contrib/contenttypes/models.py", line 133, in <module> class ContentType(models.Model): File "/usr/local/lib/python3.9/site-packages/django/db/models/base.py", line 108, in __new__ app_config = apps.get_containing_app_config(module) File "/usr/local/lib/python3.9/site-packages/django/apps/registry.py", line 253, in get_containing_app_config self.check_apps_ready() File "/usr/local/lib/python3.9/site-packages/django/apps/registry.py", line 136, in check_apps_ready raise AppRegistryNotReady("Apps aren't loaded yet.") django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.
```