### PR TITLE
Success sending events/commands via new cloudiot.client.send_command iface

### DIFF
--- a/print_nanny_vue/src/store/events/actions.ts
+++ b/print_nanny_vue/src/store/events/actions.ts
@@ -16,7 +16,7 @@ export default {
   async [STREAM_START](context: any, device: number) {
     const thisapi = api.EventsApiFactory(configuration)
     const req: api.WebRTCEventRequest = {
-      event_type: api.WebRTCEventEventTypeEnum.Start,
+      event_type: api.WebRTCEventType.Start,
       device: device,
       source: api.EventSource.PrintnannyWebapp
     }
@@ -27,7 +27,7 @@ export default {
   async [STREAM_STOP](context: any, device: number) {
     const thisapi = api.EventsApiFactory(configuration)
     const req = {
-      event_type: api.WebRTCEventEventTypeEnum.Stop,
+      event_type: api.WebRTCEventType.Stop,
       device: device,
       source: api.EventSource.PrintnannyWebapp
     }

--- a/print_nanny_webapp/events/consumers.py
+++ b/print_nanny_webapp/events/consumers.py
@@ -16,7 +16,7 @@ class EventConsumer(AsyncJsonWebsocketConsumer):
     async def connect(self):
         await self.accept()
         self.user = self.scope["user"]
-        self.group_name = f"events_{self.user.id}"
+        self.group_name = self.user.events_channel
         logger.info("Websocket connection accepted scope=%s", self.scope)
         await self.channel_layer.group_add(self.group_name, self.channel_name)
 
@@ -44,4 +44,4 @@ class EventConsumer(AsyncJsonWebsocketConsumer):
             self.group_name,
             event,
         )
-        await self.send_json(event)
+        await self.send(text_data=event)

--- a/print_nanny_webapp/events/consumers.py
+++ b/print_nanny_webapp/events/consumers.py
@@ -44,4 +44,4 @@ class EventConsumer(AsyncJsonWebsocketConsumer):
             self.group_name,
             event,
         )
-        await self.send(text_data=event)
+        await self.send_json(event)

--- a/print_nanny_webapp/events/services.py
+++ b/print_nanny_webapp/events/services.py
@@ -6,7 +6,7 @@ from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
 from django.conf import settings
 from django.apps import apps
-from rest_framework.renderers import JSONRenderer
+from rest_framework.renderers import JSONOpenAPIRenderer
 from google.cloud import iot_v1 as cloudiot_v1
 from print_nanny_webapp.devices.models import CloudiotDevice, JanusStream
 from rest_framework.renderers import JSONRenderer
@@ -110,17 +110,9 @@ def publish_channel_msg(events_channel: str, data: str):
         events_channel,
         {
             "type": "event.send",
-            # https://github.com/nathantsoi/vue-native-websocket#with-format-json-enabled
-            "data": JSONRenderer().render(data),
+            "data": JSONOpenAPIRenderer().render(data),
         },
     )
-
-
-# def webrtc_stream_start_success(event: WebRTCEvent):
-#     serializer = PolymorphicEventSerializer(instance=event)
-#     data = JSONRenderer().render(serializer.data)
-#     publish_mqtt_msg(event.device.cloudiot, data)
-#     publish_channel_msg(event.device.user.events_channel, data)
 
 
 def broadcast_event(event: Event):

--- a/print_nanny_webapp/users/models.py
+++ b/print_nanny_webapp/users/models.py
@@ -155,7 +155,7 @@ class User(AbstractUser):
         return self.email
 
     @property
-    def event_channel(self) -> str:
+    def events_channel(self) -> str:
         return f"events_{self.id}"
 
     # @property

--- a/print_nanny_webapp/utils/api/serializers.py
+++ b/print_nanny_webapp/utils/api/serializers.py
@@ -1,4 +1,6 @@
+import json
 from rest_framework import serializers
+from rest_framework.renderers import JSONOpenAPIRenderer
 
 
 class ErrorDetailSerializer(serializers.Serializer):
@@ -9,3 +11,14 @@ class ErrorDetailSerializer(serializers.Serializer):
 class PrintNannyApiConfigSerializer(serializers.Serializer):
     bearer_access_token = serializers.CharField(read_only=True)
     base_path = serializers.CharField(read_only=True)
+
+
+class JSONWebSocketRenderer(JSONOpenAPIRenderer):
+    """
+    Return json.dumps representation
+    """
+
+    def render(self, data, media_type=None, renderer_context=None):
+        return json.dumps(
+            data, cls=self.encoder_class, indent=2, ensure_ascii=self.ensure_ascii
+        )


### PR DESCRIPTION
```
print_nanny_webapp_django | INFO 2022-02-21 00:22:19,616 services 549 140332647122688 cloudiot.client.send_command_to_device response 
print_nanny_webapp_django | INFO 2022-02-21 00:22:19,616 services 549 140332647122688 Published event WebRTCEvent object (13) to MQTT commands topic
print_nanny_webapp_django | INFO 2022-02-21 00:22:19,795 httptools_impl 549 140332804278080 172.18.0.1:43372 - "POST /api/events/ HTTP/1.1" 201
print_nanny_webapp_django | INFO 2022-02-21 00:22:19,795 httptools_impl 549 140332804278080 172.18.0.1:43372 - "POST /api/events/ HTTP/1.1" 201
```