### PR TITLE
Read API_URL and WS_URL from window.location instead of config

### DIFF
--- a/print_nanny_vue/config/dev.env.js
+++ b/print_nanny_vue/config/dev.env.js
@@ -4,6 +4,4 @@ const prodEnv = require('./prod.env')
 
 module.exports = merge(prodEnv, {
   NODE_ENV: '"development"',
-  BASE_API_URL: '"http://aurora:8000"',
-  BASE_WS_URL: '"ws://aurora:8000/ws/events/"',
 })

--- a/print_nanny_vue/config/prod.env.js
+++ b/print_nanny_vue/config/prod.env.js
@@ -1,6 +1,4 @@
 'use strict'
 module.exports = {
   NODE_ENV: '"production"',
-  BASE_API_URL: '"https://www.printnanny.ai"',
-  BASE_WS_URL: '"wss://www.printnanny.ai/ws/events/"',
 }

--- a/print_nanny_vue/src/apps/AppFactory.js
+++ b/print_nanny_vue/src/apps/AppFactory.js
@@ -5,7 +5,7 @@ import store from '../store'
 import Vuelidate from '@vuelidate/core'
 import VueCompositionAPI from '@vue/composition-api'
 import { BootstrapVue } from 'bootstrap-vue'
-
+import { WS_URL } from '../services/api'
 import '@/scss/app.scss'
 
 Vue.config.productionTip = false
@@ -15,7 +15,7 @@ Vue.use(VueCookies)
 Vue.use(BootstrapVue)
 Vue.use(
   VueNativeSock,
-  process.env.BASE_WS_URL,
+  WS_URL,
   { store: store, format: 'json', reconnection: true }
 )
 

--- a/print_nanny_vue/src/services/alerts.js
+++ b/print_nanny_vue/src/services/alerts.js
@@ -1,20 +1,12 @@
 import { AlertsApiFactory, Configuration } from 'printnanny-api-client'
-
-const configuration = new Configuration({
-  basePath: process.env.BASE_API_URL,
-  baseOptions: {
-    xsrfCookieName: 'csrftoken',
-    xsrfHeaderName: 'X-CSRFTOKEN',
-    withCredentials: true
-  }
-})
+import { API_CONFIG } from './api'
 
 export default {
   async fetchAlertMethods (opts) {
 
   },
   async fetchAlerts (opts) {
-    const instance = AlertsApiFactory(configuration, process.env.BASE_API_URL)
+    const instance = AlertsApiFactory(API_CONFIG)
     const pageNum = opts ? opts.page : undefined
     const response = await instance.alertsList(pageNum)
     console.log('fetchAlerts', response)
@@ -22,13 +14,13 @@ export default {
   },
 
   async dismissAll (opts) {
-    const instance = AlertsApiFactory(configuration, process.env.BASE_API_URL)
+    const instance = AlertsApiFactory(API_CONFIG)
     const response = await instance.alertsDismiss(opts)
     console.log('dismissAll', response)
     return response
   },
   async seenAll (opts) {
-    const instance = AlertsApiFactory(configuration, process.env.BASE_API_URL)
+    const instance = AlertsApiFactory(API_CONFIG)
     const response = await instance.alertsSeen(opts)
     console.log('seenAll', response, opts)
     return response

--- a/print_nanny_vue/src/services/api.ts
+++ b/print_nanny_vue/src/services/api.ts
@@ -1,0 +1,21 @@
+import * as api from 'printnanny-api-client'
+
+const API_URL: string = window.location.origin
+const WS_PROTOCOL: string = window.location.protocol === "https:" ? "wss:" : "ws:"
+const WS_URL: string = `${WS_PROTOCOL}//${window.location.origin}/ws/events/`
+
+const API_CONFIG: api.Configuration = new api.Configuration({
+    basePath: API_URL,
+    baseOptions: {
+        xsrfCookieName: 'csrftoken',
+        xsrfHeaderName: 'X-CSRFTOKEN',
+        withCredentials: true
+    }
+})
+
+export {
+    API_CONFIG,
+    API_URL,
+    WS_PROTOCOL,
+    WS_URL
+}

--- a/print_nanny_vue/src/store/devices/actions.js
+++ b/print_nanny_vue/src/store/devices/actions.js
@@ -3,34 +3,27 @@ import {
   SET_JANUS_STREAM_DATA
 } from './mutations'
 import * as api from 'printnanny-api-client'
+import { API_CONFIG } from '../../services/api'
 
 export const GET_DEVICE = 'get_device'
 export const SETUP_JANUS_CLOUD = 'setup_janus_cloud'
 export const GET_JANUS_STREAM = 'get_janus_stream'
 
-const configuration = new api.Configuration({
-  basePath: process.env.BASE_API_URL,
-  baseOptions: {
-    xsrfCookieName: 'csrftoken',
-    xsrfHeaderName: 'X-CSRFTOKEN',
-    withCredentials: true
-  }
-})
 export default {
   async [GET_DEVICE] ({ commit, state, dispatch }, deviceId) {
-    const thisapi = api.DevicesApiFactory(configuration)
+    const thisapi = api.DevicesApiFactory(API_CONFIG)
     const res = await thisapi.devicesRetrieve(deviceId)
     console.log('Response to devicesRetrieve', res)
     commit(SET_DEVICE_DATA, res.data)
   },
   async [GET_JANUS_STREAM] ({ commit, state, dispatch }, deviceId) {
-    const thisapi = api.DevicesApiFactory(configuration)
+    const thisapi = api.DevicesApiFactory(API_CONFIG)
     const res = await thisapi.devicesJanusStreamsList(deviceId)
     console.log('Response to devicesRetrieve', res)
     commit(SET_JANUS_STREAM_DATA, res.data.results[0])
   },
   async [SETUP_JANUS_CLOUD] ({ commit, state, dispatch }, deviceId) {
-    const thisapi = api.DevicesApiFactory(configuration)
+    const thisapi = api.DevicesApiFactory(API_CONFIG)
     const req = { config_type: api.JanusConfigType.Cloud }
     const res = await thisapi.devicesJanusStreamGetOrCreate(deviceId, req)
     console.log('Response to devicesJanusStreamGetOrCreate', res)

--- a/print_nanny_vue/src/store/events/actions.ts
+++ b/print_nanny_vue/src/store/events/actions.ts
@@ -2,20 +2,14 @@ import * as api from 'printnanny-api-client'
 import { WebRTCEvent } from 'printnanny-api-client'
 import { DEVICE_MODULE, SET_JANUS_STREAM_DATA } from '../devices'
 import { SET_SENT_EVENT, SET_RECEIVED_EVENT } from './mutations'
+import { API_CONFIG } from '../../services/api'
+
 export const STREAM_START = 'STREAM_START'
 export const STREAM_STOP = 'STREAM_STOP'
 
-const configuration = new api.Configuration({
-  basePath: process.env.BASE_API_URL,
-  baseOptions: {
-    xsrfCookieName: 'csrftoken',
-    xsrfHeaderName: 'X-CSRFTOKEN',
-    withCredentials: true
-  }
-})
 export default {
   async [STREAM_START](context: any, device: number) {
-    const thisapi = api.EventsApiFactory(configuration)
+    const thisapi = api.EventsApiFactory(API_CONFIG)
     const req: api.WebRTCEventRequest = {
       model: api.WebRTCEventModel.WebRtcEvent,
       event_name: api.WebRTCEventName.Start,
@@ -30,7 +24,7 @@ export default {
     context.commit(`${DEVICE_MODULE}/${SET_JANUS_STREAM_DATA}`, event.stream, { root: true })
   },
   async [STREAM_STOP](context: any, device: number) {
-    const thisapi = api.EventsApiFactory(configuration)
+    const thisapi = api.EventsApiFactory(API_CONFIG)
     const req = {
       model: api.WebRTCEventModel.WebRtcEvent,
       event_name: api.WebRTCEventName.Stop,

--- a/print_nanny_webapp/events/services.py
+++ b/print_nanny_webapp/events/services.py
@@ -91,5 +91,6 @@ def webrtc_stream_start(event: WebRTCEvent) -> WebRTCEvent:
             device=event.device,
             user=event.user,
             send_mqtt=False,
+            stream=event.stream,
         )
         return error_event


### PR DESCRIPTION
Supports front-end JS being served from multiple domains, which would require a referred-by header set to validate CSRF token. Instead, just make requests to whatever domain is serving JS