### PR TITLE
fix missing user field in OctoPrint* views

### DIFF
--- a/print_nanny_webapp/octoprint/api/views.py
+++ b/print_nanny_webapp/octoprint/api/views.py
@@ -62,6 +62,9 @@ class OctoPrintInstallByDeviceViewSet(
     def get_queryset(self, *_args, device_id=None, **_kwargs):
         return self.queryset.filter(device=device_id)
 
+    def perform_create(self, serializer):
+        serializer.save(user=self.request.user)
+
 
 ##
 # OctoPrintInstall (no device filter)
@@ -122,6 +125,9 @@ class OctoPrintInstallViewSet(
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
+    def perform_create(self, serializer):
+        serializer.save(user=self.request.user)
+
 
 ##
 # OctoPrint Settings
@@ -179,6 +185,9 @@ class OctoPrintSettingsViewSet(
             return Response(response_serializer.data, status=status.HTTP_201_CREATED)
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def perform_create(self, serializer):
+        serializer.save(user=self.request.user)
 
 
 @extend_schema_view(
@@ -244,6 +253,9 @@ class GcodeFileViewSet(
         parsers.MultiPartParser,
     ]
 
+    def perform_create(self, serializer):
+        serializer.save(user=self.request.user)
+
 
 ##
 # OctoPrint Settings
@@ -300,3 +312,6 @@ class OctoPrinterProfileViewSet(
             return Response(response_serializer.data, status=status.HTTP_201_CREATED)
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def perform_create(self, serializer):
+        serializer.save(user=self.request.user)


### PR DESCRIPTION
Fixes the following error from PrintNanny OS devices:
```
Error: Error de/serializing content OctoprintInstallUpdateOrCreateError(ResponseError(ResponseContent { status: 500, content: "{\"error_uuid\": \"7431a85f58d74bf6a362115ed51ac979\", \"error\": \"null value in column \\\"user_id\\\" violates not-null constraint\\nDETAIL:  Failing row contains (1, null, devel, 21.2.4, 3.8.10, 0.10.0rc1, 2022-04-16 21:12:11.495457+00, 2022-04-16 21:12:11.495472+00, 1, null).\\n\"}", entity: Some(UnknownValue(Object({"error": String("null value in column \"user_id\" violates not-null constraint\nDETAIL:  Failing row contains (1, null, devel, 21.2.4, 3.8.10, 0.10.0rc1, 2022-04-16 21:12:11.495457+00, 2022-04-16 21:12:11.495472+00, 1, null).\n"), "error_uuid": String("7431a85f58d74bf6a362115ed51ac979")}))) }))
```