### PR TITLE
split request/response models to JanusStream is serialized as int in request, nested in response

### DIFF
--- a/print_nanny_webapp/events/api/views.py
+++ b/print_nanny_webapp/events/api/views.py
@@ -22,7 +22,12 @@ from print_nanny_webapp.utils.api.views import (
 )
 from print_nanny_webapp.utils.permissions import IsObjectOwner
 from print_nanny_webapp.events.models import Event
-from .serializers import PolymorphicEventSerializer, PolymorphicCommandSerializer
+from .serializers import (
+    PolymorphicEventSerializer,
+    PolymorphicCommandSerializer,
+    PolymorphicEventRequestSerializer,
+    PolymorphicCommandRequestSerializer,
+)
 
 Device = apps.get_model("devices", "Device")
 
@@ -39,7 +44,7 @@ logger = logging.getLogger(__name__)
     ),
     create=extend_schema(
         tags=["events"],
-        request=PolymorphicEventSerializer,
+        request=PolymorphicEventRequestSerializer,
         responses={
             201: PolymorphicEventSerializer,
         }
@@ -112,7 +117,7 @@ class EventViewSet(
     ),
     create=extend_schema(
         tags=["events", "commands"],
-        request=PolymorphicCommandSerializer,
+        request=PolymorphicCommandRequestSerializer,
         responses={
             201: PolymorphicCommandSerializer,
         }


### PR DESCRIPTION
Fixes the following error in the 04-18 nightly:
```
Apr 18 11:06:18 octonanny-dev-04-18 printnanny-cmd[13396]: TASK [Update stream ansible facts] *********************************************
Apr 18 11:06:18 octonanny-dev-04-18 printnanny-cmd[13396]: task path: /opt/printnanny/ansible/ansible_collections/bitsyai/printnanny/playbooks/cmd/handlers/stream_start.yml:9
Apr 18 11:06:18 octonanny-dev-04-18 printnanny-cmd[13396]: fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'int object' has no attribute 'api_domain'\n\nThe error appears to be in '/opt/printnanny/ansible/ansible_collections/bitsyai/printnanny/playbooks/cmd/handlers/stream_start.yml': line 9, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n    var: printnanny_cmd\n- name: Update stream ansible facts\n  ^ here\n"}
```