### PR TITLE
fix serializer class used in create handler

### DIFF
--- a/print_nanny_webapp/events/api/views.py
+++ b/print_nanny_webapp/events/api/views.py
@@ -79,7 +79,7 @@ class EventViewSet(
 
     def create(self, request, *args, **kwargs):
         logger.info("EventViewSet.create handling request.data %s", request.data)
-        serializer = self.get_serializer(data=request.data)
+        serializer = PolymorphicEventCreateSerializer(data=request.data)
         logger.info("EventViewSet.create got serializer %s", serializer)
         serializer.is_valid(raise_exception=True)
         logger.info("EventViewSet.create serializer is_valid=True")
@@ -152,7 +152,7 @@ class CommandViewSet(
 
     def create(self, request, *args, **kwargs):
         logger.info("EventViewSet.create handling request.data %s", request.data)
-        serializer = self.get_serializer(data=request.data)
+        serializer = PolymorphicCommandCreateSerializer(data=request.data)
         logger.info("EventViewSet.create got serializer %s", serializer)
         serializer.is_valid(raise_exception=True)
         logger.info("EventViewSet.create serializer is_valid=True")


### PR DESCRIPTION
Fixes the following error emitted by front-end build:
```
{"error_uuid": "da5db21cf5fb422e89a359b4829b17b6", "error": "null value in column \"stream_id\" violates not-null constraint\nDETAIL:  Failing row contains (159, stream_start, {}, 24, null).\n"}
```