### PR TITLE
Fix return types of devices actions.ts module

### DIFF
--- a/print_nanny_vue/src/components/JanusStream.vue
+++ b/print_nanny_vue/src/components/JanusStream.vue
@@ -154,7 +154,10 @@ const JanusStream = Vue.extend({
       this.error = null;
       const janusStream = await this.setupJanusStream();
       console.log("Calling this.streamStart with janusStream", janusStream);
-      await this.streamStart({ device: this.deviceId, stream: janusStream.id });
+      await this.streamStart({
+        device: janusStream.device.id,
+        stream: janusStream.id,
+      });
       await this.connectStream(janusStream);
     },
     async stopMonitoring() {

--- a/print_nanny_vue/src/store/devices/actions.ts
+++ b/print_nanny_vue/src/store/devices/actions.ts
@@ -4,6 +4,7 @@ import {
 } from './mutations'
 import * as api from 'printnanny-api-client'
 import { PRINTNANNY_API_CONFIG } from '../../services/api'
+import { JanusStream } from 'printnanny-api-client'
 
 export const GET_DEVICE = 'get_device'
 export const SETUP_JANUS_CLOUD = 'setup_janus_cloud'
@@ -14,13 +15,14 @@ export default {
   // TODO
   // import { ActionContext } from "vuex";
   // context: ActionContext<S,R>
-  async [GET_DEVICE](context: any, deviceId: number) {
+  async [GET_DEVICE](context: any, deviceId: number): Promise<api.Device> {
     const thisapi = api.DevicesApiFactory(PRINTNANNY_API_CONFIG)
     const res = await thisapi.devicesRetrieve(deviceId)
     console.log('Response to devicesRetrieve', res)
     context.commit(SET_DEVICE_DATA, res.data)
+    return res.data
   },
-  async [GET_JANUS_STREAM](context: any, { device, configType }: { device: number, configType: api.JanusConfigType }) {
+  async [GET_JANUS_STREAM](context: any, { device, configType }: { device: number, configType: api.JanusConfigType }): Promise<api.JanusEdgeStream | api.JanusCloudStream> {
     const thisapi = api.DevicesApiFactory(PRINTNANNY_API_CONFIG)
     let res;
     switch (configType) {
@@ -36,8 +38,9 @@ export default {
       context.commit(SET_JANUS_STREAM_DATA, res.data.results[0])
       return res.data.results[0]
     }
+    throw new Error(`No JanusStream found for device=${device} config_type=${configType}`)
   },
-  async [SETUP_JANUS_CLOUD](context: any, deviceId: number) {
+  async [SETUP_JANUS_CLOUD](context: any, deviceId: number): Promise<api.JanusCloudStream> {
     const thisapi = api.DevicesApiFactory(PRINTNANNY_API_CONFIG)
     const req = { device: deviceId }
     const res = await thisapi.devicesJanusCloudStreamGetOrCreate(deviceId, req)

--- a/print_nanny_vue/src/store/devices/actions.ts
+++ b/print_nanny_vue/src/store/devices/actions.ts
@@ -32,7 +32,10 @@ export default {
         break;
     }
     console.log('Response to devicesRetrieve', res)
-    context.commit(SET_JANUS_STREAM_DATA, res.data.results[0])
+    if (res.data.results.length >= 1) {
+      context.commit(SET_JANUS_STREAM_DATA, res.data.results[0])
+      return res.data.results[0]
+    }
   },
   async [SETUP_JANUS_CLOUD](context: any, deviceId: number) {
     const thisapi = api.DevicesApiFactory(PRINTNANNY_API_CONFIG)

--- a/print_nanny_vue/src/store/events/actions.ts
+++ b/print_nanny_vue/src/store/events/actions.ts
@@ -26,7 +26,7 @@ export default {
     console.log("eventsCreate response", res)
     context.commit(SET_SENT_EVENT, event)
   },
-  async[STREAM_STOP](context: any, { device, stream }: { device: number, stream: number }) {
+  async [STREAM_STOP](context: any, { device, stream }: { device: number, stream: number }) {
     const thisapi = api.EventsApiFactory(PRINTNANNY_API_CONFIG)
     const req: api.WebRTCCommandCreateRequest = {
       model: api.WebRTCCommandModel.WebRtcCommand,


### PR DESCRIPTION
Fixes the following error in latest OctoPrint plugin rc:
```
setting JanusStream data Object previous state Object
JanusStream.vue?993d:235 Calling this.streamStart with janusStream undefined
vue.esm.js:1897 TypeError: Cannot read properties of undefined (reading 'id')
    at s.<anonymous> (JanusStream.vue?993d:236:112)
    at JanusStream.vue?993d:43:23
    at Object.next (JanusStream.vue?993d:24:53)
    at a (JanusStream.vue?993d:15:58)
```