### PR TITLE
Fixes 400 reponse in ui build

### DIFF
--- a/print_nanny_vue/src/components/JanusStream.vue
+++ b/print_nanny_vue/src/components/JanusStream.vue
@@ -155,7 +155,7 @@ const JanusStream = Vue.extend({
       const janusStream = await this.setupJanusStream();
       console.log("Calling this.streamStart with janusStream", janusStream);
       await this.streamStart({
-        device: janusStream.device.id,
+        device: janusStream.device,
         stream: janusStream.id,
       });
       await this.connectStream(janusStream);


### PR DESCRIPTION
Resolves the following 400 in latest ui build:
```
{device: ["This field is required."], error_uuid: "ea559cc1691e4240af62610f7d26e4ba"}
device: ["This field is required."]
error_uuid: "ea559cc1691e4240af62610f7d26e4ba"
```