### PR TITLE
configure ClusterIssuer to match mender.live.printnanny.ai selector

### DIFF
--- a/k8s/templates/cluster-issuer.j2
+++ b/k8s/templates/cluster-issuer.j2
@@ -27,6 +27,7 @@ spec:
           - '*.beta.printnanny.ai'
           - live.printnanny.ai
           - '*.live.printnanny.ai'
+          - mender.live.printnanny.ai
       - dns01:
           cloudDNS:
             # The ID of the GCP project


### PR DESCRIPTION
so the wildcard cert is not used