### PR TITLE
Do not use wildcard cert for minio.live.printnanny.ai (add Selector to ClusterIssuer dnsNames)

### DIFF
--- a/k8s/templates/cluster-issuer.j2
+++ b/k8s/templates/cluster-issuer.j2
@@ -28,6 +28,7 @@ spec:
           - live.printnanny.ai
           - '*.live.printnanny.ai'
           - mender.live.printnanny.ai
+          - minio.live.printnanny.ai
       - dns01:
           cloudDNS:
             # The ID of the GCP project


### PR DESCRIPTION
…printnanny.ai wildcard)