### PR TITLE
Clean passwordless/2fa auth endpoints

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -609,6 +609,7 @@ PASSWORDLESS_AUTH = {
     "PASSWORDLESS_EMAIL_NOREPLY_ADDRESS": "noreply@print-nanny.com",
     "PASSWORDLESS_EMAIL_PLAINTEXT_MESSAGE": "Enter this token to sign in: %s",
     "PASSWORDLESS_AUTH_PREFIX": "accounts/2fa-auth/",
+    "PASSWORDLESS_VERIFY_PREFIX": "accounts/2fa-auth/verify/",
 }
 
 # django-coturn

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -608,6 +608,7 @@ PASSWORDLESS_AUTH = {
     "PASSWORDLESS_USER_MARK_EMAIL_VERIFIED": True,
     "PASSWORDLESS_EMAIL_NOREPLY_ADDRESS": "noreply@print-nanny.com",
     "PASSWORDLESS_EMAIL_PLAINTEXT_MESSAGE": "Enter this token to sign in: %s",
+    "PASSWORDLESS_AUTH_PREFIX": "accounts/2fa-auth/",
 }
 
 # django-coturn

--- a/config/urls.py
+++ b/config/urls.py
@@ -60,7 +60,7 @@ urlpatterns += [
     path("", include("django_prometheus.urls")),
     path("anymail/", include("anymail.urls")),
     # https://github.com/aaronn/django-rest-framework-passwordless
-    path("", include("drfpasswordless.urls")),
+    path("", include("print_nanny_webapp.drfpasswordless.urls")),
     re_path(r"^.*$", TemplateView.as_view(template_name="index.html")),
 ]
 

--- a/print_nanny_webapp/drfpasswordless/schema.py
+++ b/print_nanny_webapp/drfpasswordless/schema.py
@@ -2,11 +2,8 @@
 
 from drfpasswordless.serializers import (
     EmailAuthSerializer,
-    MobileAuthSerializer,
     CallbackTokenAuthSerializer,
     EmailVerificationSerializer,
-    MobileVerificationSerializer,
-    CallbackTokenVerificationSerializer,
 )
 from django.utils.module_loading import import_string
 from rest_framework import serializers
@@ -34,26 +31,7 @@ class FixObtainEmailCallbackToken(OpenApiViewExtension):
             @extend_schema(
                 request=EmailAuthSerializer,
                 responses=DetailResponseSerializer,
-                tags=[api_settings.PASSWORDLESS_AUTH_PREFIX.replace("/", "")],
-            )
-            def post(self, request, *args, **kwargs):
-                pass
-
-        return Fixed
-
-
-# /auth/mobile/
-class FixObtainMobileCallbackToken(OpenApiViewExtension):
-    target_class = "drfpasswordless.views.ObtainMobileCallbackToken"
-
-    def view_replacement(self):
-        class Fixed(self.target_class):
-            serializer_class = MobileAuthSerializer
-
-            @extend_schema(
-                request=MobileAuthSerializer,
-                responses=DetailResponseSerializer,
-                tags=[api_settings.PASSWORDLESS_AUTH_PREFIX.replace("/", "")],
+                tags=["accounts"],
             )
             def post(self, request, *args, **kwargs):
                 pass
@@ -73,7 +51,7 @@ class FixObtainAuthTokenFromCallbackToken(OpenApiViewExtension):
             @extend_schema(
                 request=CallbackTokenAuthSerializer,
                 responses=TokenResponseSerializer,
-                tags=[api_settings.PASSWORDLESS_AUTH_PREFIX.replace("/", "")],
+                tags=["accounts"],
             )
             def post(self, request, *args, **kwargs):
                 pass
@@ -94,28 +72,7 @@ class FixObtainEmailVerificationCallbackToken(OpenApiViewExtension):
             @extend_schema(
                 request=EmailVerificationSerializer,
                 responses=DetailResponseSerializer,
-                tags=[api_settings.PASSWORDLESS_AUTH_PREFIX.replace("/", "")],
-            )
-            def post(self, request, *args, **kwargs):
-                pass
-
-        return Fixed
-
-
-# /auth/verify/mobile
-# automatically sends a token attached to request.user email or mobile if available
-# (unused but wrapped for posterity)
-class FixObtainMobileVerificationCallbackToken(OpenApiViewExtension):
-    target_class = "drfpasswordless.views.ObtainMobileVerificationCallbackToken"
-
-    def view_replacement(self):
-        class Fixed(self.target_class):
-            serializer_class = MobileVerificationSerializer
-
-            @extend_schema(
-                request=MobileVerificationSerializer,
-                responses=DetailResponseSerializer,
-                tags=[api_settings.PASSWORDLESS_AUTH_PREFIX.replace("/", "")],
+                tags=["accounts"],
             )
             def post(self, request, *args, **kwargs):
                 pass

--- a/print_nanny_webapp/drfpasswordless/urls.py
+++ b/print_nanny_webapp/drfpasswordless/urls.py
@@ -13,18 +13,21 @@ from drfpasswordless.views import (
 
 app_name = "drfpasswordless"
 
-# universal endpoints
+# The "verify" endpoints below are disabled
+# Enable these if contact-point validation is needed: https://github.com/aaronn/django-rest-framework-passwordless#contact-point-validation
+
 urlpatterns = [
+    # exchange short-term 2fa code for long-term auth token
     path(
         api_settings.PASSWORDLESS_AUTH_PREFIX + "token/",
         ObtainAuthTokenFromCallbackToken.as_view(),
         name="auth_token",
     ),
-    path(
-        api_settings.PASSWORDLESS_VERIFY_PREFIX,
-        VerifyAliasFromCallbackToken.as_view(),
-        name="verify_token",
-    ),
+    # path(
+    #     api_settings.PASSWORDLESS_VERIFY_PREFIX,
+    #     VerifyAliasFromCallbackToken.as_view(),
+    #     name="verify_token",
+    # ),
 ]
 
 # PASSWORDLESS_AUTH_TYPES contains EMAIL
@@ -35,11 +38,11 @@ if "EMAIL" in api_settings.PASSWORDLESS_AUTH_TYPES:
             ObtainEmailCallbackToken.as_view(),
             name="auth_email",
         ),
-        path(
-            api_settings.PASSWORDLESS_VERIFY_PREFIX + "email/",
-            ObtainEmailVerificationCallbackToken.as_view(),
-            name="verify_email",
-        ),
+        # path(
+        #     api_settings.PASSWORDLESS_VERIFY_PREFIX + "email/",
+        #     ObtainEmailVerificationCallbackToken.as_view(),
+        #     name="verify_email",
+        # ),
     ]
 
 if "MOBILE" in api_settings.PASSWORDLESS_AUTH_TYPES:
@@ -49,10 +52,10 @@ if "MOBILE" in api_settings.PASSWORDLESS_AUTH_TYPES:
             ObtainMobileCallbackToken.as_view(),
             name="auth_mobile",
         ),
-        path(
-            api_settings.PASSWORDLESS_VERIFY_PREFIX + "mobile/",
-            ObtainMobileVerificationCallbackToken.as_view(),
-            name="verify_mobile",
-        ),
+        # path(
+        #     api_settings.PASSWORDLESS_VERIFY_PREFIX + "mobile/",
+        #     ObtainMobileVerificationCallbackToken.as_view(),
+        #     name="verify_mobile",
+        # ),
     ]
 # PASSWORDLESS_AUTH_TYPES contains MOBILE

--- a/print_nanny_webapp/drfpasswordless/urls.py
+++ b/print_nanny_webapp/drfpasswordless/urls.py
@@ -1,0 +1,58 @@
+# drfpasswordless exports all views by default
+# this shim will only export views for auth methods in PASSWORDLESS_AUTH_TYPES
+from drfpasswordless.settings import api_settings
+from django.urls import path
+from drfpasswordless.views import (
+    ObtainEmailCallbackToken,
+    ObtainMobileCallbackToken,
+    ObtainAuthTokenFromCallbackToken,
+    VerifyAliasFromCallbackToken,
+    ObtainEmailVerificationCallbackToken,
+    ObtainMobileVerificationCallbackToken,
+)
+
+app_name = "drfpasswordless"
+
+# universal endpoints
+urlpatterns = [
+    path(
+        api_settings.PASSWORDLESS_AUTH_PREFIX + "token/",
+        ObtainAuthTokenFromCallbackToken.as_view(),
+        name="auth_token",
+    ),
+    path(
+        api_settings.PASSWORDLESS_VERIFY_PREFIX,
+        VerifyAliasFromCallbackToken.as_view(),
+        name="verify_token",
+    ),
+]
+
+# PASSWORDLESS_AUTH_TYPES contains EMAIL
+if "EMAIL" in api_settings.PASSWORDLESS_AUTH_TYPES:
+    urlpatterns += [
+        path(
+            api_settings.PASSWORDLESS_AUTH_PREFIX + "email/",
+            ObtainEmailCallbackToken.as_view(),
+            name="auth_email",
+        ),
+        path(
+            api_settings.PASSWORDLESS_VERIFY_PREFIX + "email/",
+            ObtainEmailVerificationCallbackToken.as_view(),
+            name="verify_email",
+        ),
+    ]
+
+if "EMAIL" in api_settings.PASSWORDLESS_AUTH_TYPES:
+    urlpatterns += [
+        path(
+            api_settings.PASSWORDLESS_AUTH_PREFIX + "mobile/",
+            ObtainMobileCallbackToken.as_view(),
+            name="auth_mobile",
+        ),
+        path(
+            api_settings.PASSWORDLESS_VERIFY_PREFIX + "mobile/",
+            ObtainMobileVerificationCallbackToken.as_view(),
+            name="verify_mobile",
+        ),
+    ]
+# PASSWORDLESS_AUTH_TYPES contains MOBILE

--- a/print_nanny_webapp/drfpasswordless/urls.py
+++ b/print_nanny_webapp/drfpasswordless/urls.py
@@ -42,7 +42,7 @@ if "EMAIL" in api_settings.PASSWORDLESS_AUTH_TYPES:
         ),
     ]
 
-if "EMAIL" in api_settings.PASSWORDLESS_AUTH_TYPES:
+if "MOBILE" in api_settings.PASSWORDLESS_AUTH_TYPES:
     urlpatterns += [
         path(
             api_settings.PASSWORDLESS_AUTH_PREFIX + "mobile/",


### PR DESCRIPTION
* Remove unused mobile endpoints
* Serve from /accounts/2fa-auth/ path

Part of: https://github.com/bitsy-ai/printnanny-os/issues/56