### PR TITLE
set CSRF_TRUSTED_ORIGINS for .printnanny.ai

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -53,6 +53,7 @@ SESSION_COOKIE_SECURE = True
 CSRF_COOKIE_SECURE = True
 # https://docs.djangoproject.com/en/3.2/ref/settings/#csrf-cookie-domain
 CSRF_COOKIE_DOMAIN = env("DJANGO_CSRF_COOKIE_DOMAIN", default=".printnanny.ai")
+CSRF_TRUSTED_ORIGINS = [".printnanny.ai"]
 # https://docs.djangoproject.com/en/dev/topics/security/#ssl-https
 # https://docs.djangoproject.com/en/dev/ref/settings/#secure-hsts-seconds
 # TODO: set this to 60 seconds first and then to 518400 once you prove the former works


### PR DESCRIPTION
Fixes operation marked as "unsafe" failing with error:

```
Oops, unexpected error

CSRF Failed: Referer checking failed - no Referer.
```

These were previously same-site, but are now x-site between printnanny.ai -> api.printnanny.ai