### PR TITLE
Derive clap::ValueEnum in generated Rust client

### DIFF
--- a/client-templates/rust-client-codegen/src/main/java/com/printnanny/api/rust/RustClientGenerator.java
+++ b/client-templates/rust-client-codegen/src/main/java/com/printnanny/api/rust/RustClientGenerator.java
@@ -39,6 +39,7 @@ public class RustClientGenerator extends DefaultCodegen implements CodegenConfig
   private boolean useSingleRequestParameter = false;
   private boolean supportAsync = true;
   private boolean supportMultipleResponses = false;
+  private boolean deriveClapValueEnum = false;
 
   public static final String PACKAGE_NAME = "packageName";
   public static final String PACKAGE_VERSION = "packageVersion";
@@ -46,6 +47,7 @@ public class RustClientGenerator extends DefaultCodegen implements CodegenConfig
   public static final String REQWEST_LIBRARY = "reqwest";
   public static final String SUPPORT_ASYNC = "supportAsync";
   public static final String SUPPORT_MULTIPLE_RESPONSES = "supportMultipleResponses";
+  public static final String DERIVE_CLAP_VALUE_ENUM = "deriveClapValueEnum";
 
   protected String packageName = "openapi";
   protected String packageVersion = "1.0.0";
@@ -170,18 +172,21 @@ public class RustClientGenerator extends DefaultCodegen implements CodegenConfig
             .defaultValue(Boolean.TRUE.toString()));
     cliOptions.add(new CliOption(CodegenConstants.USE_SINGLE_REQUEST_PARAMETER,
         CodegenConstants.USE_SINGLE_REQUEST_PARAMETER_DESC, SchemaTypeUtil.BOOLEAN_TYPE)
-            .defaultValue(Boolean.FALSE.toString()));
+        .defaultValue(Boolean.FALSE.toString()));
     cliOptions.add(new CliOption(SUPPORT_ASYNC,
         "If set, generate async function call instead. This option is for 'reqwest' library only",
         SchemaTypeUtil.BOOLEAN_TYPE)
-            .defaultValue(Boolean.TRUE.toString()));
+        .defaultValue(Boolean.TRUE.toString()));
     cliOptions.add(new CliOption(SUPPORT_MULTIPLE_RESPONSES,
         "If set, return type wraps an enum of all possible 2xx schemas. This option is for 'reqwest' library only",
         SchemaTypeUtil.BOOLEAN_TYPE)
-            .defaultValue(Boolean.FALSE.toString()));
+        .defaultValue(Boolean.FALSE.toString()));
     cliOptions.add(new CliOption(CodegenConstants.ENUM_NAME_SUFFIX, CodegenConstants.ENUM_NAME_SUFFIX_DESC)
         .defaultValue(this.enumSuffix));
-
+    cliOptions.add(new CliOption(DERIVE_CLAP_VALUE_ENUM,
+        "If set, an additional sized enum will be generated deriving clap::ValueEnum. This option is useful for building a CLI wrapper for your OpenAPI schema.",
+        SchemaTypeUtil.BOOLEAN_TYPE)
+        .defaultValue(Boolean.FALSE.toString()));
     supportedLibraries.put(HYPER_LIBRARY, "HTTP client: Hyper.");
     supportedLibraries.put(REQWEST_LIBRARY, "HTTP client: Reqwest.");
 
@@ -281,6 +286,11 @@ public class RustClientGenerator extends DefaultCodegen implements CodegenConfig
     }
     writePropertyBack(SUPPORT_ASYNC, getSupportAsync());
 
+    if (additionalProperties.containsKey(DERIVE_CLAP_VALUE_ENUM)) {
+      this.setDeriveClapValueEnum(convertPropertyToBoolean(DERIVE_CLAP_VALUE_ENUM));
+    }
+    writePropertyBack(DERIVE_CLAP_VALUE_ENUM, getDeriveClapValueEnum());
+
     if (additionalProperties.containsKey(SUPPORT_MULTIPLE_RESPONSES)) {
       this.setSupportMultipleReturns(convertPropertyToBoolean(SUPPORT_MULTIPLE_RESPONSES));
     }
@@ -319,6 +329,14 @@ public class RustClientGenerator extends DefaultCodegen implements CodegenConfig
       supportingFiles.add(new SupportingFile("request.rs", apiFolder, "request.rs"));
       supportingFiles.add(new SupportingFile(getLibrary() + "/client.mustache", apiFolder, "client.rs"));
     }
+  }
+
+  private boolean getDeriveClapValueEnum() {
+    return deriveClapValueEnum;
+  }
+
+  private void setDeriveClapValueEnum(boolean deriveClapValueEnum) {
+    this.deriveClapValueEnum = deriveClapValueEnum;
   }
 
   private boolean getSupportAsync() {

--- a/client-templates/rust-client-codegen/src/main/resources/rust-client/Cargo.mustache
+++ b/client-templates/rust-client-codegen/src/main/resources/rust-client/Cargo.mustache
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 {{#deriveClapValueEnum}}
-clap = { version = "^3.2", features = ["dervive"] }
+clap = { version = "^3.2", features = ["derive"] }
 {{/deriveClapValueEnum}}
 bytes = "1.1.0"
 serde = "^1.0"

--- a/client-templates/rust-client-codegen/src/main/resources/rust-client/Cargo.mustache
+++ b/client-templates/rust-client-codegen/src/main/resources/rust-client/Cargo.mustache
@@ -9,6 +9,9 @@ description = "Official Print Nanny Rust API Client"
 edition = "2018"
 
 [dependencies]
+{{#deriveClapValueEnum}}
+clap = { version = "^3.2", features = ["dervive"] }
+{{/deriveClapValueEnum}}
 bytes = "1.1.0"
 serde = "^1.0"
 serde_derive = "^1.0"

--- a/client-templates/rust-client-codegen/src/main/resources/rust-client/model.mustache
+++ b/client-templates/rust-client-codegen/src/main/resources/rust-client/model.mustache
@@ -8,7 +8,7 @@
 {{!-- for enum schemas --}}
 {{#isEnum}}
 /// {{{description}}}
-#[derive(Clone, Copy,{{#deriveClapValueEnum}}clap::ValueEnum,{{/deriveClapValueEnum}} Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy,{{#deriveClapValueEnum}} clap::ValueEnum,{{/deriveClapValueEnum}} Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum {{{classname}}} {
 {{#allowableValues}}
 {{#enumVars}}

--- a/client-templates/rust-client-codegen/src/main/resources/rust-client/model.mustache
+++ b/client-templates/rust-client-codegen/src/main/resources/rust-client/model.mustache
@@ -8,7 +8,7 @@
 {{!-- for enum schemas --}}
 {{#isEnum}}
 /// {{{description}}}
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy,{{#deriveClapValueEnum}}clap::ValueEnum,{{/deriveClapValueEnum}} Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum {{{classname}}} {
 {{#allowableValues}}
 {{#enumVars}}

--- a/clients/rust.yaml
+++ b/clients/rust.yaml
@@ -2,3 +2,4 @@
 packageName: printnanny-api-client
 packageVersion: "0.99.4"
 appDescription: "Official Rust PrintNanny API Client"
+deriveClapValueEnum: true

--- a/clients/rust.yaml
+++ b/clients/rust.yaml
@@ -1,4 +1,4 @@
 ---
 packageName: printnanny-api-client
 packageVersion: "0.99.4"
-appDescription: "Official Rust Print Nanny API Client"
+appDescription: "Official Rust PrintNanny API Client"

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -9,6 +9,7 @@ description = "Official Print Nanny Rust API Client"
 edition = "2018"
 
 [dependencies]
+clap = { version = "^3.2", features = ["derive"] }
 bytes = "1.1.0"
 serde = "^1.0"
 serde_derive = "^1.0"

--- a/clients/rust/src/models/collection_method_enum.rs
+++ b/clients/rust/src/models/collection_method_enum.rs
@@ -10,7 +10,7 @@
 
 
 /// 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, clap::ValueEnum, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum CollectionMethodEnum {
     #[serde(rename = "charge_automatically")]
     ChargeAutomatically,

--- a/clients/rust/src/models/end_behavior_enum.rs
+++ b/clients/rust/src/models/end_behavior_enum.rs
@@ -10,7 +10,7 @@
 
 
 /// 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, clap::ValueEnum, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum EndBehaviorEnum {
     #[serde(rename = "cancel")]
     Cancel,

--- a/clients/rust/src/models/event_types_enum.rs
+++ b/clients/rust/src/models/event_types_enum.rs
@@ -10,7 +10,7 @@
 
 
 /// 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, clap::ValueEnum, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum EventTypesEnum {
     #[serde(rename = "PrintQuality")]
     PrintQuality,

--- a/clients/rust/src/models/interval_enum.rs
+++ b/clients/rust/src/models/interval_enum.rs
@@ -10,7 +10,7 @@
 
 
 /// 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, clap::ValueEnum, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum IntervalEnum {
     #[serde(rename = "day")]
     Day,

--- a/clients/rust/src/models/janus_config_type.rs
+++ b/clients/rust/src/models/janus_config_type.rs
@@ -10,7 +10,7 @@
 
 
 /// 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, clap::ValueEnum, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum JanusConfigType {
     #[serde(rename = "cloud")]
     Cloud,

--- a/clients/rust/src/models/os_edition.rs
+++ b/clients/rust/src/models/os_edition.rs
@@ -10,7 +10,7 @@
 
 
 /// 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, clap::ValueEnum, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum OsEdition {
     #[serde(rename = "octoprint_lite")]
     OctoprintLite,

--- a/clients/rust/src/models/pi_boot_command_type.rs
+++ b/clients/rust/src/models/pi_boot_command_type.rs
@@ -10,7 +10,7 @@
 
 
 /// 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, clap::ValueEnum, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum PiBootCommandType {
     #[serde(rename = "Reboot")]
     Reboot,

--- a/clients/rust/src/models/pi_boot_event_type.rs
+++ b/clients/rust/src/models/pi_boot_event_type.rs
@@ -10,7 +10,7 @@
 
 
 /// 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, clap::ValueEnum, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum PiBootEventType {
     #[serde(rename = "RebootStarted")]
     RebootStarted,

--- a/clients/rust/src/models/pi_gstreamer_command_type.rs
+++ b/clients/rust/src/models/pi_gstreamer_command_type.rs
@@ -10,7 +10,7 @@
 
 
 /// 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, clap::ValueEnum, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum PiGstreamerCommandType {
     #[serde(rename = "Start")]
     Start,

--- a/clients/rust/src/models/pi_software_update_event_type.rs
+++ b/clients/rust/src/models/pi_software_update_event_type.rs
@@ -10,7 +10,7 @@
 
 
 /// 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, clap::ValueEnum, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum PiSoftwareUpdateEventType {
     #[serde(rename = "Started")]
     Started,

--- a/clients/rust/src/models/sbc_enum.rs
+++ b/clients/rust/src/models/sbc_enum.rs
@@ -10,7 +10,7 @@
 
 
 /// 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, clap::ValueEnum, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum SbcEnum {
     #[serde(rename = "rpi_4")]
     Rpi4,

--- a/clients/rust/src/models/stripe_subscription_schedule_status_enum.rs
+++ b/clients/rust/src/models/stripe_subscription_schedule_status_enum.rs
@@ -10,7 +10,7 @@
 
 
 /// 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, clap::ValueEnum, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum StripeSubscriptionScheduleStatusEnum {
     #[serde(rename = "active")]
     Active,

--- a/clients/rust/src/models/stripe_subscription_status_enum.rs
+++ b/clients/rust/src/models/stripe_subscription_status_enum.rs
@@ -10,7 +10,7 @@
 
 
 /// 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, clap::ValueEnum, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum StripeSubscriptionStatusEnum {
     #[serde(rename = "active")]
     Active,

--- a/clients/rust/src/models/tax_exempt_enum.rs
+++ b/clients/rust/src/models/tax_exempt_enum.rs
@@ -10,7 +10,7 @@
 
 
 /// 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, clap::ValueEnum, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum TaxExemptEnum {
     #[serde(rename = "exempt")]
     Exempt,

--- a/clients/rust/src/models/type_enum.rs
+++ b/clients/rust/src/models/type_enum.rs
@@ -10,7 +10,7 @@
 
 
 /// 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, clap::ValueEnum, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum TypeEnum {
     #[serde(rename = "acss_debit")]
     AcssDebit,

--- a/clients/rust/src/models/usage_type_enum.rs
+++ b/clients/rust/src/models/usage_type_enum.rs
@@ -10,7 +10,7 @@
 
 
 /// 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, clap::ValueEnum, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum UsageTypeEnum {
     #[serde(rename = "licensed")]
     Licensed,


### PR DESCRIPTION
Allows us to easily expose endpoints/model payload construction via clap CLI