### PR TITLE
fix PiNatsApp.objects manager

### DIFF
--- a/print_nanny_webapp/devices/models.py
+++ b/print_nanny_webapp/devices/models.py
@@ -7,12 +7,13 @@ from django.db import models
 from django.contrib.auth import get_user_model
 from django.db.models import UniqueConstraint
 from django.utils.crypto import get_random_string
-from safedelete.models import SafeDeleteModel, SOFT_DELETE
+from safedelete.models import SafeDeleteModel, SOFT_DELETE, SafeDeleteManager
 
 from django_nats_nkeys.models import (
     AbstractNatsApp,
     NatsOrganization,
     NatsOrganizationUser,
+    NatsOrganizationAppManager,
 )
 
 from print_nanny_webapp.devices.utils import get_available_rtp_port
@@ -163,8 +164,13 @@ class Pi(SafeDeleteModel):
         return self.cloudiot_device
 
 
+class PiNatsAppManager(SafeDeleteManager, NatsOrganizationAppManager):
+    pass
+
+
 # add Pi foreign key reference to NatsApp
 class PiNatsApp(AbstractNatsApp, SafeDeleteModel):
+    objects = PiNatsAppManager()
     pi = models.ForeignKey(Pi, on_delete=models.CASCADE)
     organization_user = models.ForeignKey(
         NatsOrganizationUser, on_delete=models.CASCADE, related_name="nats_pi_apps"


### PR DESCRIPTION
Fixes error after upgrading to django-nats-nkeys 0.6.x:
```
Traceback (most recent call last): File "/usr/local/lib/python3.9/site-packages/rest_framework/views.py", line 506, in dispatch response = handler(request, *args, **kwargs) File "/app/./print_nanny_webapp/devices/api/views.py", line 466, in download_zip zip_content = build_license_zip(pi, request) File "/app/./print_nanny_webapp/devices/services.py", line 121, in build_license_zip nats_app = create_pi_nats_app(pi) File "/app/./print_nanny_webapp/devices/services.py", line 99, in create_pi_nats_app app = PiNatsApp.objects.create_nsc( AttributeError: 'SafeDeleteManager' object has no attribute 'create_nsc'
```