### PR TITLE
initialize robots in management cmd

### DIFF
--- a/compose/local/django/start.sh
+++ b/compose/local/django/start.sh
@@ -6,6 +6,7 @@ set -o nounset
 
 python manage.py collectstatic --noinput
 python manage.py migrate
+python manage.py initrobots
 
 
 # set the nsc store directory

--- a/compose/production/django/start.sh
+++ b/compose/production/django/start.sh
@@ -22,6 +22,7 @@ END
 }
 
 python manage.py migrate
+python manage.py initrobots
 
 # if compress_enabled; then
 #   # NOTE this command will fail if django-compressor is disabled

--- a/print_nanny_webapp/events/management/commands/initrobots.py
+++ b/print_nanny_webapp/events/management/commands/initrobots.py
@@ -1,0 +1,41 @@
+import logging
+from django.core.management.base import BaseCommand
+from django.contrib.auth import get_user_model
+from django.apps import apps
+
+
+logger = logging.getLogger(__name__)
+User = get_user_model()
+
+NatsRobotAccount = apps.get_model("django_nats_nkeys.NatsRobotAccount")
+NatsRobotApp = apps.get_model("django_nats_nkeys.NatsRobotApp")
+
+
+def get_robot_acccount(name):
+    try:
+        return NatsRobotAccount.objects.get(name=name)
+    except NatsRobotAccount.DoesNotExist:
+        return NatsRobotAccount.objects.create_nsc(name=name)
+
+
+def get_robot_app(account, app_name):
+    try:
+        return NatsRobotApp.objects.get(
+            app_name=app_name,
+            account=account,
+        )
+    except NatsRobotApp.DoesNotExist:
+        return NatsRobotApp.objects.create_nsc(app_name=app_name, account=account)
+
+
+class Command(BaseCommand):
+    help = "Initializes a robot account/app (indempotent)"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--name", type=str, default="firehose")
+
+    def handle(self, *args, **kwargs):
+        name = kwargs.get("name")
+        account = get_robot_acccount(name)
+        app = get_robot_app(account, name)
+        logger.info("NatsRobotApp initialized %s", app.json)


### PR DESCRIPTION
Sleep `firehose` service until robot account/credentials have been initialized. Currently failing because nsc volume is mounted read-only in the firehose container.
```
ERROR 2022-08-18 19:56:02,797 services 1 140517383436032 Error: error creating `/var/lib/nats/nsc/keys/keys/A/CO`: mkdir /var/lib/nats/nsc/keys/keys/A/CO: read-only file system
```