### PR TITLE
Simplify license contents

### DIFF
--- a/config/api_router.py
+++ b/config/api_router.py
@@ -9,7 +9,6 @@ from print_nanny_webapp.devices.api.views import (
     PiViewSet,
     WebrtcStreamViewSet,
     PiLicenseZipViewset,
-    PiLicenseJsonViewSet,
     PiSettingsViewSet,
 )
 from print_nanny_webapp.events.api.views import (
@@ -72,7 +71,6 @@ pi_router.register("events/commands", SinglePiCommandsViewSet, basename="pi-comm
 
 
 pi_router.register("license", PiLicenseZipViewset, basename="license-zip")
-pi_router.register("license", PiLicenseJsonViewSet, basename="license-api-json")
 
 pi_router.register("settings", PiSettingsViewSet, basename="settings")
 pi_router.register(r"webrtc-streams", WebrtcStreamViewSet, basename="janus-streams")

--- a/print_nanny_webapp/devices/api/views.py
+++ b/print_nanny_webapp/devices/api/views.py
@@ -427,6 +427,6 @@ class PiLicenseZipViewset(
         zip_content = build_license_zip(pi)
 
         response = HttpResponse(zip_content, content_type=ZipRenderer.media_type)
-        filename = f"printnanny-{pi.hostname}.zip"
+        filename = "license.zip"
         response["Content-Disposition"] = f"attachment; filename={filename}"
         return response

--- a/print_nanny_webapp/devices/management/commands/devconfig.py
+++ b/print_nanny_webapp/devices/management/commands/devconfig.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
         request.user = user
         request.META["HTTP_HOST"] = f"{options['hostname']}:{options['port']}"
 
-        zipdata = build_license_zip(device, request)
+        zipdata = build_license_zip(device)
         with open(options["out"], "wb+") as f:
             f.write(zipdata)
         self.stdout.write(self.style.SUCCESS(f"Created {options['out']}"))

--- a/print_nanny_webapp/devices/services.py
+++ b/print_nanny_webapp/devices/services.py
@@ -19,7 +19,6 @@ from django_nats_nkeys.models import (
     _default_name,
 )
 from django_nats_nkeys.services import create_organization, nsc_generate_creds
-from rest_framework.renderers import JSONRenderer
 from print_nanny_webapp.utils.api.service import get_api_config
 from print_nanny_webapp.devices.enum import JanusConfigType
 from print_nanny_webapp.devices.api.serializers import PrintNannyLicenseSerializer
@@ -413,19 +412,14 @@ def get_license_serializer(pi: Pi, request: HttpRequest) -> PrintNannyLicenseSer
     return PrintNannyLicenseSerializer(dict(api=api, pi=pi))
 
 
-def build_license_zip(pi: Pi, request: HttpRequest) -> bytes:
+def build_license_zip(pi: Pi) -> bytes:
 
     nats_app = get_or_create_pi_nats_app(pi)
-
-    license_serializer = get_license_serializer(pi, request)
-
     nats_creds = nsc_generate_creds(
         nats_app.organization.name, app_name=nats_app.app_name
     )
-
     creds_bundle = [
-        ("license.json", JSONRenderer().render(license_serializer.data)),
-        ("nats.creds", nats_creds),
+        ("printnanny-cloud-nats.creds", nats_creds),
     ]
 
     # do not write sensitive credentials to disk


### PR DESCRIPTION
I'm getting reports that point to a race condition when unpacking license content. The race goes something like:

- PrintNanny Edge NATS worker receives connect token (after 2FA)
- PrintNanny Edge NATS worker thread1 attempts to download + unpack license
- Client hasn't received a response yet, retries
- PrintNanny Edge NATs worker thread2 attempts to download + unpack license

Worker threads are now racing to unpack/write zip contents. `unpack_seed` will fail if any files in the zip already exist, which can easily happen with a multi-threaded worker model. The NATs credential provisioning process is slow (lots of synchronization involved), so the client might retry multiple times while waiting for a response.
https://github.com/bitsy-ai/printnanny-cli/blob/main/services/src/paths.rs#L212


Cleaning this up and simplifying:

- Remove license.json, which is no longer needed (connect 2fa passes token)
- Rename `nats.creds` to `printnanny-cloud-nats.creds` for clarity
- Change the default behavior of `unpack_license` to backup existing files and always create new
- Use a lockfile or other mutex for configuration+credential changes