### PR TITLE
Explicitly pass workload identity token/email in url signing request

### DIFF
--- a/print_nanny_webapp/utils/storages.py
+++ b/print_nanny_webapp/utils/storages.py
@@ -1,19 +1,12 @@
 from storages.backends.gcloud import GoogleCloudStorage
-from google.cloud import storage
-from datetime import datetime, timedelta
 from typing import Dict, Any
 import google.auth
-
-credentials, project_id = google.auth.default()
 
 # Perform a refresh request to get the access token of the current credentials (Else, it's None)
 from google.auth.transport import requests
 from storages.utils import (
-    check_location,
     clean_name,
-    get_available_overwrite_name,
     safe_join,
-    setting,
 )
 
 
@@ -26,6 +19,7 @@ class StaticRootGoogleCloudStorage(GoogleCloudStorage):
 class SignBlob:
     def get_sign_kwargs(self) -> Dict[str, Any]:
         r = requests.Request()
+        credentials, project_id = google.auth.default()
         credentials.refresh(r)
         return {
             "service_account_email": credentials.service_account_email,

--- a/setup.cfg
+++ b/setup.cfg
@@ -143,6 +143,9 @@ ignore_errors = True
 [mypy-storages.*]
 ignore_missing_imports = True
 
+[mypy-google.auth.*]
+ignore_missing_imports = True
+
 [mypy-google.cloud.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
Based on: https://stackoverflow.com/questions/64234214/how-to-generate-a-blob-signed-url-in-google-cloud-run

A possible solution to the following error, thrown when using workload identity in GKE
```
AttributeError: you need a private key to sign credentials.the credentials you are currently using <class 'google.auth.compute_engine.credentials.Credentials'> just contains a token. see https://googleapis.dev/python/google-api-core/latest/auth.html#setting-up-a-service-account for more details.
```
https://github.com/jschneier/django-storages/issues/1107