### PR TITLE
Add a CSRF excempt decorator to VideoRecordingViewSet.update_or_create

### DIFF
--- a/print_nanny_webapp/devices/api/views.py
+++ b/print_nanny_webapp/devices/api/views.py
@@ -368,7 +368,6 @@ class SystemInfoViewSet(
             # 400: PrinterProfileSerializer,
             200: SystemInfoSerializer,
             201: SystemInfoSerializer,
-            202: SystemInfoSerializer,
         },
     )
     @action(methods=["post"], detail=False, url_path="update-or-create")

--- a/print_nanny_webapp/videos/api/views.py
+++ b/print_nanny_webapp/videos/api/views.py
@@ -2,10 +2,9 @@ import logging
 
 from drf_spectacular.utils import extend_schema_view, extend_schema
 
+from django.views.decorators.csrf import csrf_exempt
 from rest_framework.response import Response
 from rest_framework.decorators import action
-from rest_framework.permissions import IsAuthenticated
-from rest_framework.permissions import AllowAny
 from rest_framework.viewsets import GenericViewSet
 from rest_framework.mixins import (
     ListModelMixin,
@@ -13,7 +12,6 @@ from rest_framework.mixins import (
     UpdateModelMixin,
     CreateModelMixin,
 )
-from rest_framework import parsers
 from rest_framework import status
 
 
@@ -86,12 +84,13 @@ class VideoRecordingViewSet(
         tags=["videos"],
         responses={
             200: VideoRecordingSerializer,
-            202: VideoRecordingSerializer,
+            201: VideoRecordingSerializer,
         }
         | generic_create_errors
         | generic_get_errors,
     )
     @action(methods=["post"], detail=True, url_path="update-or-create")
+    @csrf_exempt
     def update_or_create(self, request, pk=None):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)


### PR DESCRIPTION
This exemption is usually applied when using API bearer token authentication, but I think the file field type is re-applying the CSRF check. Since we're generating a signed upload URL in the storage backend for our upload, we don't need CSRF checking here.
