### PR TITLE
Implement: POST /accounts/2fa-auth/session/

### DIFF
--- a/clients/typescript/api.ts
+++ b/clients/typescript/api.ts
@@ -7074,6 +7074,47 @@ export const AccountsApiAxiosParamCreator = function (configuration?: Configurat
             };
         },
         /**
+         * Persist a user id and a backend in the request. This way a user doesn\'t have to reauthenticate on every request. Note that data set during the anonymous session is retained when the user logs in.
+         * @param {CallbackTokenAuthRequest} callbackTokenAuthRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        accounts2faAuthSessionCreate: async (callbackTokenAuthRequest: CallbackTokenAuthRequest, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'callbackTokenAuthRequest' is not null or undefined
+            assertParamExists('accounts2faAuthSessionCreate', 'callbackTokenAuthRequest', callbackTokenAuthRequest)
+            const localVarPath = `/accounts/2fa-auth/session/`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication cookieAuth required
+
+            // authentication tokenAuth required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(callbackTokenAuthRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * This is a duplicate of rest_framework\'s own ObtainAuthToken method. Instead, this returns an Auth Token based on our callback token and source.
          * @param {CallbackTokenAuthRequest} callbackTokenAuthRequest 
          * @param {*} [options] Override http request option.
@@ -7648,6 +7689,16 @@ export const AccountsApiFp = function(configuration?: Configuration) {
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
+         * Persist a user id and a backend in the request. This way a user doesn\'t have to reauthenticate on every request. Note that data set during the anonymous session is retained when the user logs in.
+         * @param {CallbackTokenAuthRequest} callbackTokenAuthRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async accounts2faAuthSessionCreate(callbackTokenAuthRequest: CallbackTokenAuthRequest, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CallbackTokenAuth>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.accounts2faAuthSessionCreate(callbackTokenAuthRequest, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
          * This is a duplicate of rest_framework\'s own ObtainAuthToken method. Instead, this returns an Auth Token based on our callback token and source.
          * @param {CallbackTokenAuthRequest} callbackTokenAuthRequest 
          * @param {*} [options] Override http request option.
@@ -7804,6 +7855,15 @@ export const AccountsApiFactory = function (configuration?: Configuration, baseP
             return localVarFp.accounts2faAuthEmailCreate(emailAuthRequest, options).then((request) => request(axios, basePath));
         },
         /**
+         * Persist a user id and a backend in the request. This way a user doesn\'t have to reauthenticate on every request. Note that data set during the anonymous session is retained when the user logs in.
+         * @param {CallbackTokenAuthRequest} callbackTokenAuthRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        accounts2faAuthSessionCreate(callbackTokenAuthRequest: CallbackTokenAuthRequest, options?: any): AxiosPromise<CallbackTokenAuth> {
+            return localVarFp.accounts2faAuthSessionCreate(callbackTokenAuthRequest, options).then((request) => request(axios, basePath));
+        },
+        /**
          * This is a duplicate of rest_framework\'s own ObtainAuthToken method. Instead, this returns an Auth Token based on our callback token and source.
          * @param {CallbackTokenAuthRequest} callbackTokenAuthRequest 
          * @param {*} [options] Override http request option.
@@ -7943,6 +8003,15 @@ export interface AccountsApiInterface {
      * @memberof AccountsApiInterface
      */
     accounts2faAuthEmailCreate(emailAuthRequest: EmailAuthRequest, options?: AxiosRequestConfig): AxiosPromise<EmailAuth>;
+
+    /**
+     * Persist a user id and a backend in the request. This way a user doesn\'t have to reauthenticate on every request. Note that data set during the anonymous session is retained when the user logs in.
+     * @param {CallbackTokenAuthRequest} callbackTokenAuthRequest 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof AccountsApiInterface
+     */
+    accounts2faAuthSessionCreate(callbackTokenAuthRequest: CallbackTokenAuthRequest, options?: AxiosRequestConfig): AxiosPromise<CallbackTokenAuth>;
 
     /**
      * This is a duplicate of rest_framework\'s own ObtainAuthToken method. Instead, this returns an Auth Token based on our callback token and source.
@@ -8085,6 +8154,17 @@ export class AccountsApi extends BaseAPI implements AccountsApiInterface {
      */
     public accounts2faAuthEmailCreate(emailAuthRequest: EmailAuthRequest, options?: AxiosRequestConfig) {
         return AccountsApiFp(this.configuration).accounts2faAuthEmailCreate(emailAuthRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Persist a user id and a backend in the request. This way a user doesn\'t have to reauthenticate on every request. Note that data set during the anonymous session is retained when the user logs in.
+     * @param {CallbackTokenAuthRequest} callbackTokenAuthRequest 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof AccountsApi
+     */
+    public accounts2faAuthSessionCreate(callbackTokenAuthRequest: CallbackTokenAuthRequest, options?: AxiosRequestConfig) {
+        return AccountsApiFp(this.configuration).accounts2faAuthSessionCreate(callbackTokenAuthRequest, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -120,8 +120,8 @@ MIGRATION_MODULES = {"sites": "print_nanny_webapp.contrib.sites.migrations"}
 # https://docs.djangoproject.com/en/dev/ref/settings/#authentication-backends
 AUTHENTICATION_BACKENDS = [
     "oauth2_provider.backends.OAuth2Backend",
+    "print_nanny_webapp.drfpasswordless.backends.PasswordlessBackend",
     "django.contrib.auth.backends.ModelBackend",
-    "allauth.account.auth_backends.AuthenticationBackend",
 ]
 # https://docs.djangoproject.com/en/dev/ref/settings/#auth-user-model
 AUTH_USER_MODEL = "users.User"

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -119,7 +119,7 @@ BETA_NOTIFY_EMAIL = ["leigh+testing@bitsy.ai"]
 
 # CORS
 # ------------------------------------------------------------------------------
-CORS_ORIGIN_WHITELIST = ["http://localhost:8080"]
+CORS_ORIGIN_WHITELIST = ["http://localhost:8080", "http://localhost:3000"]
 
 # LOGGING
 # ------------------------------------------------------------------------------

--- a/print_nanny_webapp/drfpasswordless/backends.py
+++ b/print_nanny_webapp/drfpasswordless/backends.py
@@ -1,0 +1,23 @@
+from django.utils.module_loading import import_string
+from drfpasswordless.settings import api_settings
+from django.contrib.auth import get_user_model
+from django.core.exceptions import SuspiciousOperation
+
+UserModel = get_user_model()
+
+
+class PasswordlessBackend:
+    """
+    Authentication backend used with passwordless 2fa
+    """
+
+    def authenticate(self, request=None, user=None, **credentials):
+        if user is None:
+            return
+        return user
+
+    def get_user(self, user_id):
+        try:
+            return UserModel.objects.get(id=user_id)
+        except UserModel.DoesNotExist:
+            return None

--- a/print_nanny_webapp/drfpasswordless/urls.py
+++ b/print_nanny_webapp/drfpasswordless/urls.py
@@ -7,6 +7,7 @@ from drfpasswordless.views import (
     ObtainMobileCallbackToken,
     ObtainAuthTokenFromCallbackToken,
 )
+from .views import ObtainAuthTokenAndSessionCookieFromCallbackToken
 
 app_name = "drfpasswordless"
 
@@ -14,17 +15,18 @@ app_name = "drfpasswordless"
 # Enable these if contact-point validation is needed: https://github.com/aaronn/django-rest-framework-passwordless#contact-point-validation
 
 urlpatterns = [
-    # exchange short-term 2fa code for long-term auth token
+    # exchange short-term 2fa code for bearer auth token
     path(
         api_settings.PASSWORDLESS_AUTH_PREFIX + "token/",
         ObtainAuthTokenFromCallbackToken.as_view(),
         name="auth_token",
     ),
-    # path(
-    #     api_settings.PASSWORDLESS_VERIFY_PREFIX,
-    #     VerifyAliasFromCallbackToken.as_view(),
-    #     name="verify_token",
-    # ),
+    # exchange short-term 2fa code for bearer auth token and authenticated session cookie
+    path(
+        api_settings.PASSWORDLESS_AUTH_PREFIX + "session/",
+        ObtainAuthTokenAndSessionCookieFromCallbackToken.as_view(),
+        name="auth_session",
+    ),
 ]
 
 # PASSWORDLESS_AUTH_TYPES contains EMAIL
@@ -41,6 +43,7 @@ if "EMAIL" in api_settings.PASSWORDLESS_AUTH_TYPES:
         #     name="verify_email",
         # ),
     ]
+
 
 if "MOBILE" in api_settings.PASSWORDLESS_AUTH_TYPES:
     urlpatterns += [

--- a/print_nanny_webapp/drfpasswordless/views.py
+++ b/print_nanny_webapp/drfpasswordless/views.py
@@ -1,0 +1,52 @@
+import logging
+
+from drfpasswordless.views import (
+    ObtainAuthTokenFromCallbackToken,
+)
+from django.contrib.auth import login
+from django.utils.module_loading import import_string
+from drfpasswordless.settings import api_settings
+from rest_framework.response import Response
+from rest_framework import status
+
+logger = logging.getLogger(__name__)
+
+
+class ObtainAuthTokenAndSessionCookieFromCallbackToken(
+    ObtainAuthTokenFromCallbackToken
+):
+    """
+    Persist a user id and a backend in the request. This way a user doesn't
+    have to reauthenticate on every request. Note that data set during
+    the anonymous session is retained when the user logs in.
+    """
+
+    def post(self, request, *args, **kwargs):
+        serializer = self.serializer_class(data=request.data)
+        if serializer.is_valid(raise_exception=True):
+            user = serializer.validated_data["user"]
+            token_creator = import_string(api_settings.PASSWORDLESS_AUTH_TOKEN_CREATOR)
+            (token, _) = token_creator(user)
+
+            if token:
+                TokenSerializer = import_string(
+                    api_settings.PASSWORDLESS_AUTH_TOKEN_SERIALIZER
+                )
+                token_serializer = TokenSerializer(data=token.__dict__, partial=True)
+                if token_serializer.is_valid():
+                    login(
+                        request,
+                        user,
+                        backend="print_nanny_webapp.drfpasswordless.backends.PasswordlessBackend",
+                    )
+                    return Response(token_serializer.data, status=status.HTTP_200_OK)
+        else:
+            logger.error(
+                "Couldn't log in unknown user. Errors on serializer: {}".format(
+                    serializer.error_messages
+                )
+            )
+        return Response(
+            {"detail": "Couldn't log you in. Try again later."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )

--- a/ui/src/stores/account.ts
+++ b/ui/src/stores/account.ts
@@ -10,7 +10,7 @@ export const useAccountStore = defineStore({
   id: "accounts",
   // persist option provided by: https://github.com/prazdevs/pinia-plugin-persistedstate
   persist: {
-    storage: localStorage,
+    storage: sessionStorage
   },
   state: () => ({
     email: undefined as undefined | string,
@@ -161,7 +161,7 @@ export const useAccountStore = defineStore({
     async twoFactorStage2(email: string, token: string): Promise<boolean> {
       const req = { email, token } as api.CallbackTokenAuthRequest;
       const res = await this.accountsApi
-        .accounts2faAuthTokenCreate(req)
+        .accounts2faAuthSessionCreate(req) // accounts2faAuthSessionCreate returns a bearer token as well as setting a session authentication cookie
         .catch(handleApiError);
       console.debug("accounts2faAuthTokenCreate response: ", res);
       const ok = res !== undefined && res.status === 200;


### PR DESCRIPTION
 This API method is similar to POST /accounts/2fa-auth/token/ but also sets a session cookie

closes: https://github.com/bitsy-ai/printnanny-os/issues/262