### PR TITLE
OctoPrint events admin panels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ PRINT_NANNY_URL ?= http://localhost:8080/
 PRINT_NANNY_API_URL ?= ${PRINT_NANNY_URL}api/
 OCTOPRINT_URL ?= http://localhost:5005/
 PRINT_NANNY_USER ?= ${USER}
-DJANGO_SUPERUSER_EMAIL ?= ${USER}@print-nanny.com
-DJANGO_SUPERUSER_PASSWORD ?= $(shell test -f .password && cat .password || (makepasswd --chars=42 > .password && cat .password) )
+DJANGO_SUPERUSER_EMAIL ?= admin@printnanny.ai
+DJANGO_SUPERUSER_PASSWORD ?= debug1234
 DJANGO_ADMIN_CMD ?= docker-compose -f local.yml run --rm django python manage.py
 NEBULA_VERSION ?= v1.4.0
 PRINT_NANNY_TOKEN ?= $(shell test -f .token && cat .token || (${DJANGO_ADMIN_CMD} drf_create_token $(DJANGO_SUPERUSER_EMAIL) | tail -n 1 | awk '{print $$3}'> .token && cat .token))

--- a/print_nanny_webapp/octoprint/admin.py
+++ b/print_nanny_webapp/octoprint/admin.py
@@ -5,7 +5,59 @@ from print_nanny_webapp.octoprint.models import (
     OctoPrinterProfile,
     OctoPrintSettings,
     GcodeFile,
+    OctoPrintServerStatus,
+    OctoPrintPrinterStatus,
+    OctoPrintPrintJobStatus,
+    OctoPrintGcodeEvent,
 )
+
+
+@admin.register(OctoPrintServerStatus)
+class OctoPrintServerStatusAdmin(admin.ModelAdmin):
+    list_display = (
+        "event_type",
+        "pi",
+        "subject_pattern",
+        "octoprint_server",
+        "created_dt",
+    )
+    model = OctoPrintServerStatus
+
+
+@admin.register(OctoPrintGcodeEvent)
+class OctoPrintGcodeEventAdmin(admin.ModelAdmin):
+    list_display = (
+        "event_type",
+        "pi",
+        "subject_pattern",
+        "octoprint_server",
+        "created_dt",
+    )
+    model = OctoPrintGcodeEvent
+
+
+@admin.register(OctoPrintPrinterStatus)
+class OctoPrintPrinterStatusAdmin(admin.ModelAdmin):
+    list_display = (
+        "event_type",
+        "pi",
+        "subject_pattern",
+        "octoprint_server",
+        "created_dt",
+    )
+    model = OctoPrintPrinterStatus
+
+
+@admin.register(OctoPrintPrintJobStatus)
+class OctoPrintPrintJobStatusAdmin(admin.ModelAdmin):
+    list_display = (
+        "event_type",
+        "pi",
+        "subject_pattern",
+        "octoprint_server",
+        "created_dt",
+    )
+    model = OctoPrintPrintJobStatus
 
 
 @admin.register(OctoPrintBackup)


### PR DESCRIPTION
and a hard-coded default superuser password, which is just used for local development. the randomly-generated superuser password was annoying to use for development
