### PR TITLE
do not fetch user account data on every route transition (ffs Leigh)

### DIFF
--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -51,7 +51,6 @@ router.beforeEach(async (to, _from) => {
     return;
   }
   const account = useAccountStore();
-  await account.fetchUser();
   if (
     // make sure the user is authenticated
     !account.isAuthenticated &&


### PR DESCRIPTION
closes: https://github.com/bitsy-ai/printnanny-os/issues/298

I've been slamming PrintNanny's database when marketing campaigns / social shares go out, since this route guard attempts to fetch user data on every route transition. Let's not 😂 