### PR TITLE
fix: DEFAULT_FROM_EMAIL

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -295,7 +295,7 @@ EMAIL_BACKEND = env(
 EMAIL_TIMEOUT = 5
 
 DEFAULT_FROM_EMAIL = env(
-    "DJANGO_DEFAULT_FROM_EMAIL", default="PrintNanny <noreply@printnanny.ai>"
+    "DJANGO_DEFAULT_FROM_EMAIL", default="PrintNanny <noreply@mail.printnanny.ai>"
 )
 # https://docs.djangoproject.com/en/dev/ref/settings/#server-email
 SERVER_EMAIL = env("DJANGO_SERVER_EMAIL", default=DEFAULT_FROM_EMAIL)


### PR DESCRIPTION
Our Mailgun email domain should be `mail.printnanny.ai` to match the SPF + MX records set for Mailgun. I think certain ISPs or email providers are black-holing transactional emails from Mailgun using the top-level domain, `printnanny.ai since the top level uses Google's MX records. 